### PR TITLE
Feat/region taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 * Added `Region taxonomy name` field to the settings. This is for partners that use a custom taxonomy to add
   a region to their post
 
+## 0.8.4
+* We now support featured images when saving a post to ABC Manager
+
+## 0.8.3
+* Don't send articles to ABC when they are already send from ABC
+
+## 0.8.2
+* Implement extra credentials check
+* Fix some logics on retrieving bearer token from ABC
+* Rename some labels for fields
+* Add notice on classic editor when the post is successfully send to ABC Manager
+
 ## 0.8.1
 * Added a `composer.json` with scripts to check code quality, using tools like PHPStan and PHP CodeSniffer.
   * Run `composer phpcheck` to check the code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.5
+* Added `Region taxonomy name` field to the settings. This is for partners that use a custom taxonomy to add
+  a region to their post
+
 ## 0.8.1
 * Added a `composer.json` with scripts to check code quality, using tools like PHPStan and PHP CodeSniffer.
   * Run `composer phpcheck` to check the code.

--- a/abc-local-partner-wp-plugin.php
+++ b/abc-local-partner-wp-plugin.php
@@ -15,7 +15,7 @@
  * Plugin Name:         ABC Manager - Local Partner
  * Plugin URI:          https://github.com/rtvnh/abc-local-partner-wp-plugin
  * Description:         WordPress Plugin to post new updates to the ABC Manager of NH/AT5
- * Version:             0.8.4
+ * Version:             0.8.5
  * Author:              AngryBytes B.V.
  * Author URI:          https://angrybytes.com
  * License:             GPL-2.0+


### PR DESCRIPTION
<!--
Please make sure to read the contributing guidelines:
https://github.com/rtvnh/abc-local-partner-wp-plugin/blob/develop/CONTRIBUTING.md
-->

<!-- What has changed? -->
# Changelog
* Added `Region taxonomy name` field to the settings. This is for partners that use a custom taxonomy to add
  a region to their post

<!-- Go over all points below and tick the checkboxes that apply. -->
## Checklist
- [ ] The code styling conforms to [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/).
- [ ] The code styling checks have passed.
- [ ] The version number has been updated in [abc-local-partner-wp-plugin.php](https://github.com/rtvnh/abc-local-partner-wp-plugin/blob/develop/abc-local-partner-wp-plugin.php#L8)
- [ ] The changelog has been updated.
